### PR TITLE
[feat] Optimistic locking with version number for update resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ appsyncgen is a CLI providing some useful capability to develop GraphQL API with
 * Export resolver list by JSON so that you can easily implement CDK stack.
 * Generate CloudFormation Template automatically.
 * Generate Pipeline resolvers for your queries and mutations so that you can slot in your custom business logic between generated resolvers.
+* Optimistic locking with version number for update resolver
 * **TypeScript** support is coming soon.
 
 ## Concepts

--- a/codegen/resolver/mutation.go
+++ b/codegen/resolver/mutation.go
@@ -59,6 +59,11 @@ func (r *Resolver) generateUpdateResolver(exportPath string, tmpl *template.Temp
 	if obj.Type.Name == "Connection" {
 		return
 	}
+	fileForGet := r.createResolverFile(exportPath, "Mutation")
+	templates.ExecuteTemplate(templates.DynamoDBResolverTemplateData{
+		PK: returnType,
+		SK: returnType,
+	}, dynamodb.GetItem, fileForGet, tmpl)
 	attributes := fields.Names()
 	file := r.createResolverFile(exportPath, "Mutation")
 	templates.ExecuteTemplate(templates.DynamoDBResolverTemplateData{

--- a/codegen/templates/resolver/dynamodb/get_item.tmpl
+++ b/codegen/templates/resolver/dynamodb/get_item.tmpl
@@ -1,7 +1,7 @@
 import { util } from '@aws-appsync/utils';
 
 export function request(ctx){
-  const { id } = ctx.args;
+  const id = ctx.args.id || ctx.args.input.id;
   return {
     operation: 'GetItem',
     key: util.dynamodb.toMapValues({PK: `{{ .PK }}#${id}`, SK: `{{ .SK }}#${id}`}),

--- a/codegen/templates/resolver/dynamodb/put_item.tmpl
+++ b/codegen/templates/resolver/dynamodb/put_item.tmpl
@@ -19,6 +19,7 @@ export function request(ctx){
       id: id,
       createdAt: createdAt,
       updatedAt: createdAt,
+      _version: 1,
       {{- range .Attributes }}
       {{if ne . "id"}}{{ . }}: input.{{ . }},{{end}}
       {{- end }}

--- a/codegen/templates/resolver/dynamodb/transact_put_items.tmpl
+++ b/codegen/templates/resolver/dynamodb/transact_put_items.tmpl
@@ -20,6 +20,7 @@ export function request(ctx) {
           id: id,
           createdAt: createdAt,
           updatedAt: createdAt,
+          _version: 1,
           {{- range .Attributes }}
           {{ if ne . "id" }}{{ . }}: input.{{ . }},{{ end }}
           {{- end }}

--- a/codegen/templates/resolver/dynamodb/update_item.tmpl
+++ b/codegen/templates/resolver/dynamodb/update_item.tmpl
@@ -1,30 +1,64 @@
 import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
-  const { input } = ctx.args;
-  const updatedAt = util.time.nowISO8601();
-    return {
-      operation: 'UpdateItem',
-      key: util.dynamodb.toMapValues({PK: `{{ .PK }}#${input.id}`,SK: `{{ .SK }}#${input.id}`}),
-      update: {
-        expression: "SET {{ range .Attributes }} {{ . }} = :{{ . }},{{ end }} updatedAt = :updatedAt",
-        expressionValues: util.dynamodb.toMapValues({
-          {{ range .Attributes }}
-          ':{{ . }}' : input.{{ . }},
-          {{ end }}
-          ':updatedAt': updatedAt
-        })
-      }
-    }
+  const { args: { input: { id, ...values } } } = ctx;
+
+  const condition = {
+    id: { attributeExists: true },
+    _version: { eq: ctx.prev.result._version },
+  };
+  values['_version'] = ctx.prev.result._version + 1;
+  return dynamodbUpdateRequest({ keys: { PK: `{{ .PK }}#${id}`, SK: `{{ .SK }}#${id}` }, values, condition });
 }
 
 export function response(ctx){
-  const { result } = ctx;
   if (ctx.error){
     util.error(ctx.error.message, ctx.error.type, ctx.result)
   }
   return {
     {{ .PK | toLowerCase}}ID: ctx.result.id,
     ...ctx.result,
+  };
+}
+
+/**
+ * Helper function to update an item
+ * @returns an UpdateItem request
+ */
+function dynamodbUpdateRequest(params) {
+  const { keys, values, condition: inCondObj } = params;
+
+  const sets = [];
+  const removes = [];
+  const expressionNames = {};
+  const expValues = {};
+
+  // Iterate through the keys of the values
+  for (const [key, value] of Object.entries(values)) {
+    expressionNames[`#${key}`] = key;
+    if (value) {
+      sets.push(`#${key} = :${key}`);
+      expValues[`:${key}`] = value;
+    } else {
+      removes.push(`#${key}`);
+    }
   }
+
+  let expression = sets.length ? `SET ${sets.join(', ')}` : '';
+  expression += removes.length ? ` REMOVE ${removes.join(', ')}` : '';
+
+  const condition = JSON.parse(
+    util.transform.toDynamoDBConditionExpression(inCondObj)
+  );
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues(keys),
+    condition,
+    update: {
+      expression,
+      expressionNames,
+      expressionValues: util.dynamodb.toMapValues(expValues),
+    },
+  };
 }


### PR DESCRIPTION
With Amplify CLI, `_version` is optional, hence it is totally up to client whether resolver update item with optimistic locking or without it. This is critical problem if optimistic locking is required (e.g. Inventory control). So I think that update resolver shouldn't have option to execute without condition for DynamoDB UpdateItem.